### PR TITLE
Feature/user input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 notes.txt
+*.code-workspace

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -34,7 +34,7 @@ const daySelectorEl = $('select[name="day"]');
 //FUNCTIONS
 
 // Populate user input 'days' dropdown with correct # of days for given month
-function setNumDaysInMonth(month){
+function setNumDays(month){
     var firstOfThisMonth = DateTime.fromFormat(`${month} 1 ${DUMMY_LEAP_YR}`, 'MMMM d y');
     var firstOfNextMonth = firstOfThisMonth.plus({months: 1});
     var daysInMonth = firstOfNextMonth.diff(firstOfThisMonth, 'days').toObject().days;
@@ -73,7 +73,7 @@ function getHoroscope(month, day){
             })
         })
         .catch(error =>
-            console.log('system error') //UPDATE LATER with something that the user can actually see
+            console.log('system error') //UPDATE LATER with something that the user can actually see (a modal?)
         );
 }
 
@@ -97,7 +97,7 @@ function getSignName(month, day){
 //Update # of days when month is (re-)selected
 monthSelectorEl.on('change', function(event){
     event.preventDefault();
-    setNumDaysInMonth($(this).val());
+    setNumDays($(this).val());
 });
 
 
@@ -106,8 +106,6 @@ $('#birthday-input').on('submit', function(event){
     event.preventDefault();
     getHoroscope(monthSelectorEl.val(), daySelectorEl.val());
 });
-
-
 
 
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -87,3 +87,15 @@ function getSignName(month, day){
     else
         return 'capricorn';
 }
+
+
+
+//LISTENERS
+$('select[name="month"]').on('change', function(){
+    setNumDaysInMonth($(this).val());
+});
+
+
+
+//INITIALIZE PAGE
+$('select[name="month"]').trigger('change'); // initializes day dropdown to correct # of days for the initial month

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -26,6 +26,9 @@ const SIGNS = [
     new Sign('sagittarius', 356)
 ];
 
+const monthSelectorEl = $('select[name="month"]');
+const daySelectorEl = $('select[name="day"]');
+
 
 
 //FUNCTIONS
@@ -36,15 +39,14 @@ function setNumDaysInMonth(month){
     var firstOfNextMonth = firstOfThisMonth.plus({months: 1});
     var daysInMonth = firstOfNextMonth.diff(firstOfThisMonth, 'days').toObject().days;
 
-    var dayInputEl = $('select[name="day"]')
-    var daySelected = dayInputEl.val() || 1;
+    var daySelected = daySelectorEl.val() || 1;
     
-    dayInputEl.empty();
+    daySelectorEl.empty();
     for (i = 1; i <= daysInMonth; i++)
-        dayInputEl.append($(`<option value='${i}'>${i}</option>`));
-        
+        daySelectorEl.append($(`<option value='${i}'>${i}</option>`));
+
     if (daySelected <= daysInMonth)
-        dayInputEl.val(daySelected);
+        daySelectorEl.val(daySelected);
 }
 
 
@@ -63,7 +65,6 @@ function getHoroscope(month, day){
     )
         .then(response => response.json())
         .then(data => {
-            console.log(data);
             return {
                 color: data.color,
                 desc: data.description,
@@ -93,7 +94,7 @@ function getSignName(month, day){
 
 
 //LISTENERS
-$('select[name="month"]').on('change', function(event){
+monthSelectorEl.on('change', function(event){
     event.preventDefault();
     setNumDaysInMonth($(this).val());
 });
@@ -101,4 +102,6 @@ $('select[name="month"]').on('change', function(event){
 
 
 //INITIALIZE PAGE
-$('select[name="month"]').trigger('change'); // initializes day dropdown to correct # of days for the initial month
+monthSelectorEl.val(DateTime.now().toFormat('MMMM').toLowerCase()); // set initial month to today's
+monthSelectorEl.trigger('change'); // initialize day dropdown w/ correct # of days for the initial month
+daySelectorEl.val(+DateTime.now().toFormat('d')); // set initial day-of-month to today's

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -30,6 +30,22 @@ const SIGNS = [
 
 //FUNCTIONS
 
+// Populate user input 'days' dropdown with correct # of days for given month
+function setNumDaysInMonth(month){
+    var firstOfThisMonth = DateTime.fromFormat(`${month} 1 ${DUMMY_LEAP_YR}`, 'MMMM d y');
+    var firstOfNextMonth = firstOfThisMonth.plus({months: 1});
+
+    var daysInMonth = firstOfNextMonth.diff(firstOfThisMonth, 'days').toObject().days;
+
+    var dayInputEl = $('select[name="day"]')
+        .empty();
+
+    for (i = 1; i <= daysInMonth; i++){
+        dayInputEl.append($(`<option value='${i}'>${i}</option>`));
+    }
+}
+
+
 // Get horoscope based on sign name
 function getHoroscope(month, day){
     var signName = getSignName(month, day);

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -34,15 +34,17 @@ const SIGNS = [
 function setNumDaysInMonth(month){
     var firstOfThisMonth = DateTime.fromFormat(`${month} 1 ${DUMMY_LEAP_YR}`, 'MMMM d y');
     var firstOfNextMonth = firstOfThisMonth.plus({months: 1});
-
     var daysInMonth = firstOfNextMonth.diff(firstOfThisMonth, 'days').toObject().days;
 
     var dayInputEl = $('select[name="day"]')
-        .empty();
-
-    for (i = 1; i <= daysInMonth; i++){
+    var daySelected = dayInputEl.val() || 1;
+    
+    dayInputEl.empty();
+    for (i = 1; i <= daysInMonth; i++)
         dayInputEl.append($(`<option value='${i}'>${i}</option>`));
-    }
+        
+    if (daySelected <= daysInMonth)
+        dayInputEl.val(daySelected);
 }
 
 
@@ -91,7 +93,8 @@ function getSignName(month, day){
 
 
 //LISTENERS
-$('select[name="month"]').on('change', function(){
+$('select[name="month"]').on('change', function(event){
+    event.preventDefault();
     setNumDaysInMonth($(this).val());
 });
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -65,17 +65,16 @@ function getHoroscope(month, day){
     )
         .then(response => response.json())
         .then(data => {
-            return {
+            console.log({ //MARIELLE: THIS OBJECT will need to be passed directly to the keyword extractor from this point
                 color: data.color,
                 desc: data.description,
                 luckyNum: data.lucky_number,
                 mood: data.mood
-            };
+            })
         })
         .catch(error =>
-            console.log('system error')
+            console.log('system error') //UPDATE LATER with something that the user can actually see
         );
-
 }
 
 
@@ -94,10 +93,21 @@ function getSignName(month, day){
 
 
 //LISTENERS
+
+//Update # of days when month is (re-)selected
 monthSelectorEl.on('change', function(event){
     event.preventDefault();
     setNumDaysInMonth($(this).val());
 });
+
+
+//Upon birthday submission, begin the chain of API calls
+$('#birthday-input').on('submit', function(event){
+    event.preventDefault();
+    getHoroscope(monthSelectorEl.val(), daySelectorEl.val());
+});
+
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,30 @@
     <title>Document</title>
 </head>
 <body>
+    <form id="birthday-input">
+        <label>When's your birthday?</label>
+        <select name="month" form="birthday-input" required autofocus>
+            <option value="january">January</option>
+            <option value="february">February</option>
+            <option value="march">March</option>
+            <option value="april">April</option>
+            <option value="may">May</option>
+            <option value="june">June</option>
+            <option value="july">July</option>
+            <option value="august">August</option>
+            <option value="september">September</option>
+            <option value="october">October</option>
+            <option value="november">November</option>
+            <option value="december">December</option>
+        </select>
+        <select name="day" form="birthday-input" required>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+        </select>
+        <button type="submit">Get it</button>
+    </form>
+
     <script src="https://cdn.jsdelivr.net/npm/luxon@2.4.0/build/global/luxon.min.js"></script>
     <script src="./assets/js/script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <button type="submit">Get it</button>
     </form>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" referrerpolicy="no-referrer"></script>
     <script src="https://cdn.jsdelivr.net/npm/luxon@2.4.0/build/global/luxon.min.js"></script>
     <script src="./assets/js/script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -24,11 +24,7 @@
             <option value="november">November</option>
             <option value="december">December</option>
         </select>
-        <select name="day" form="birthday-input" required>
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-        </select>
+        <select name="day" form="birthday-input" required></select>
         <button type="submit">Get it</button>
     </form>
 


### PR DESCRIPTION
This resolves the ["User inputs birthdate" issue](https://github.com/noah35becker/fuzzy-enigma/issues/3).

- There's now basic HTML for the user to input their birthday month and day.
- Upon page load, the initial birthday value is set to today's date.
- The correct # of days appears based on the selected month.
- If a day is selected, and then the user re-selects the month, it updates the # of days in the day dropdown while _holding on_ to the day that was already selected (unless the day nows falls out of bounds, e.g. the day was set to 31 but they just changed the month to February, in which case the day resets to 1).

@mnwana, you'll also notice a small note for you (on line 68 of the script.js) about how we'll need to handle passing the horoscope data off to the keyword extractor.

