### PR TITLE
Get hex code of an image's dominant color

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -70,6 +70,9 @@ function getHoroscope(month, day){
                 luckyNum: data.lucky_number,
                 mood: data.mood
             };
+
+            // Send horoscopeObj.color to an image generator, then pass the image to getDomColor() to generate the page's background color based on user submission
+
             extractFromText(horoscopeObj,"topics");
 //             extractFromText(horoscopeObj,"feelings");
         })
@@ -90,6 +93,18 @@ function getSignName(month, day){
     else
         return 'capricorn';
 }
+
+
+// Get hex code of an image's dominant color
+function getDomColor(imageURL){
+    fetch(`https://api.sightengine.com/1.0/check.json?models=properties&api_user=1573388445&api_secret=ekggwH3iTJryZir7enN3&url=${imageURL}`)
+        .then(response => response.json())
+        .then(data => console.log(data.colors.dominant.hex))
+        .catch(error =>
+            console.log('system error') //UPDATE LATER with something that the user can actually see (a modal?)
+        )
+}
+
 
 // Get key feelings or topics given text input, extractType options = ["topics","feelings"]
 function extractFromText(horoscopeObj, extractType) {


### PR DESCRIPTION
This takes us part of the way towards completing the ["Background color" issue](https://github.com/noah35becker/fuzzy-enigma/issues/18).

getDomColor(imageURL) returns the hex code of the dominant color in a given image.

The next step, which I'll do on the feature/images branch, is to find an image generator API (something in lieu of DALL-E-2, for the time being). We can use this image generator API for the original purpose that we had intended; we can _also_ use it to generate an image based on the horoscope's color, which we'll then send to this new getDomColor function in order to get a hex code to use as the page's background color.